### PR TITLE
Add support for exclusive jobs

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -632,9 +632,9 @@
       "dev": true
     },
     "@quirrel/owl": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.2.3.tgz",
-      "integrity": "sha512-C08x/qm9YkUxkz9v/VhmedCNrPRDfML3RWyN0+zi7AgG+1gpDJlqWZGzP7gevnF+9YqOOfavj2KOOhRz64+qPA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.3.0.tgz",
+      "integrity": "sha512-YwUEMYm0OehBry+NsxGnJVxSIrPVhtA35xxEbytClgNRK/bTd8a0GL/zI0cd4MgftFTNJ0DWjfKPXf+bcKMLWQ==",
       "requires": {
         "debug": "^4.2.0",
         "ioredis": "^4.17.3",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -632,9 +632,9 @@
       "dev": true
     },
     "@quirrel/owl": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.3.0.tgz",
-      "integrity": "sha512-YwUEMYm0OehBry+NsxGnJVxSIrPVhtA35xxEbytClgNRK/bTd8a0GL/zI0cd4MgftFTNJ0DWjfKPXf+bcKMLWQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.3.1.tgz",
+      "integrity": "sha512-isQ8oXkebMTsuueVF8tQV/O43EwKiiQwUNfQcU7wbVKW6UaDa8mlj2R8gRPoqPiyC+EWN3cE8lvUHBSMCdpeWA==",
       "requires": {
         "debug": "^4.2.0",
         "ioredis": "^4.17.3",

--- a/api/package.json
+++ b/api/package.json
@@ -45,7 +45,7 @@
     "websocket": "^1.0.32"
   },
   "dependencies": {
-    "@quirrel/owl": "^0.3.0",
+    "@quirrel/owl": "^0.3.1",
     "@sentry/node": "^5.26.0",
     "@sentry/tracing": "^5.26.0",
     "axios": "^0.20.0",

--- a/api/package.json
+++ b/api/package.json
@@ -45,7 +45,7 @@
     "websocket": "^1.0.32"
   },
   "dependencies": {
-    "@quirrel/owl": "^0.2.3",
+    "@quirrel/owl": "^0.3.0",
     "@sentry/node": "^5.26.0",
     "@sentry/tracing": "^5.26.0",
     "axios": "^0.20.0",

--- a/api/src/scheduler/jobs-repo.ts
+++ b/api/src/scheduler/jobs-repo.ts
@@ -19,6 +19,7 @@ interface JobDTO {
   endpoint: string;
   body: string;
   runAt: string;
+  exclusive: boolean;
   repeat?: {
     every?: number;
     times?: number;
@@ -44,6 +45,7 @@ export class JobsRepo {
       endpoint,
       body: job.payload,
       runAt: job.runAt.toISOString(),
+      exclusive: job.exclusive,
       repeat: job.schedule
         ? {
             count: job.count,
@@ -125,6 +127,7 @@ export class JobsRepo {
       delay,
       repeat,
       override,
+      exclusive,
     }: POSTQueuesEndpointBody
   ) {
     if (typeof id === "undefined") {
@@ -169,6 +172,7 @@ export class JobsRepo {
       id,
       payload: body ?? "",
       runAt,
+      exclusive,
       schedule: schedule_type
         ? {
             type: schedule_type,

--- a/api/src/scheduler/schemas/queues/POST/body.json
+++ b/api/src/scheduler/schemas/queues/POST/body.json
@@ -16,6 +16,7 @@
       "type": "string"
     },
     "override": { "type": "boolean" },
+    "exclusive": { "type": "boolean" },
     "repeat": {
       "type": "object",
       "properties": {

--- a/api/test/activity.test.ts
+++ b/api/test/activity.test.ts
@@ -104,6 +104,7 @@ function testAgainst(backend: "Redis" | "Mock") {
         endpoint: decodeURIComponent(endpoint),
         id: job2id,
         runAt: new Date(now + 300).toISOString(),
+        exclusive: false,
       },
     ]);
     expect(log).toContainEqual([

--- a/api/test/jobs.test.ts
+++ b/api/test/jobs.test.ts
@@ -94,6 +94,7 @@ function testAgainst(backend: "Redis" | "Mock") {
             this: "willBeRetrieved",
             nr: 1,
           }),
+          exclusive: false,
           endpoint: decodeURIComponent(endpoint),
         });
         expect(jobsWithoutRunAt).toContainEqual({
@@ -102,6 +103,7 @@ function testAgainst(backend: "Redis" | "Mock") {
             this: "willBeRetrieved",
             nr: 2,
           }),
+          exclusive: false,
           endpoint: decodeURIComponent(endpoint),
         });
 
@@ -135,6 +137,7 @@ function testAgainst(backend: "Redis" | "Mock") {
           id,
           body: JSON.stringify({ this: "willBeRetrieved" }),
           endpoint: decodeURIComponent(endpoint),
+          exclusive: false,
         });
 
         expect(+new Date(jobRunAt)).toBeCloseTo(+new Date(runAt), -3);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -702,9 +702,9 @@
       }
     },
     "@types/ioredis": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.17.5.tgz",
-      "integrity": "sha512-MkG9WEGozGBDL869a0WJUBfDKodOFSfRfR4zSfq610MrdL9l+ToyHPyNqa4oSvAAAmldo06Gq1V+EzFRrNByfQ==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.17.7.tgz",
+      "integrity": "sha512-M8/KDSGmNYhPFMn+CxDDpIEHP27b2muEHgnK1UgIQIMEO2KXH9mznHx3epeRlD+AjF94HFh3dy2/9zqO+pPDqQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -3622,7 +3622,7 @@
       "version": "file:../api",
       "dev": true,
       "requires": {
-        "@quirrel/owl": "^0.2.3",
+        "@quirrel/owl": "^0.3.1",
         "@sentry/node": "^5.26.0",
         "@sentry/tracing": "^5.26.0",
         "axios": "^0.20.0",

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/quirrel-dev/quirrel#readme",
   "devDependencies": {
-    "@types/ioredis": "^4.17.5",
+    "@types/ioredis": "^4.17.7",
     "@types/ms": "^0.7.31",
     "@types/node": "^14.11.2",
     "delay": "^4.4.0",

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -41,6 +41,12 @@ export interface JobDTO {
   readonly runAt: string;
 
   /**
+   * Guarantees that no other job (from the same queue)
+   * is executed while this job is being executed.
+   */
+  readonly exclusive: boolean;
+
+  /**
    * Present if the job has been scheduled to repeat.
    */
   readonly repeat?: {
@@ -80,6 +86,13 @@ export interface BaseEnqueueJobOpts {
    * @tutorial https://demo.quirrel.dev/managed
    */
   id?: string;
+
+  /**
+   * If set to `true`,
+   * no other job (on the same queue)
+   * will be executed at the same time.
+   */
+  exclusive?: boolean;
 
   repeat?: {
     /**

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -129,6 +129,8 @@ export interface EnqueueJobOpts {
   };
 }
 
+export type DefaultJobOptions = Pick<EnqueueJobOpts, "exclusive">
+
 export interface Job extends Omit<JobDTO, "runAt" | "body"> {
   /**
    * Date that the job has been scheduled for.
@@ -185,6 +187,8 @@ interface QuirrelClientOpts {
    * @see https://docs.quirrel.dev/faq#my-encryption-secret-has-been-leaked-what-now
    */
   oldSecrets?: string[];
+
+  defaultJobOptions?: DefaultJobOptions;
 }
 
 export class QuirrelClient {
@@ -192,6 +196,7 @@ export class QuirrelClient {
 
   private readonly token;
   private readonly baseUrl;
+  private readonly defaultJobOptions: DefaultJobOptions;
 
   /**
    * Constructs a new Quirrel Client.
@@ -219,6 +224,7 @@ export class QuirrelClient {
 
     this.token = enrichedOpts.token;
     this.baseUrl = enrichedOpts.baseUrl;
+    this.defaultJobOptions = opts.defaultJobOptions ?? {};
   }
 
   private getAuthHeaders(): Record<string, string> {
@@ -280,6 +286,7 @@ export class QuirrelClient {
           ...this.getAuthHeaders(),
         },
         body: JSON.stringify({
+          ...this.defaultJobOptions,
           body: stringifiedBody,
           delay,
           id: opts.id,

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -74,7 +74,7 @@ export interface JobDTO {
   };
 }
 
-export interface BaseEnqueueJobOpts {
+export interface EnqueueJobOpts {
   /**
    * The job's payload.
    */
@@ -93,6 +93,18 @@ export interface BaseEnqueueJobOpts {
    * will be executed at the same time.
    */
   exclusive?: boolean;
+
+  /**
+   * Will delay the job's execution by the specified amount of milliseconds.
+   * Supports human-readable notation as of @see https://github.com/vercel/ms.
+   * If used together with `repeat`, this will delay the first job to be executed.
+   */
+  delay?: number | string;
+
+  /**
+   * Schedules the job for execution at the specified timestamp.
+   */
+  runAt?: Date;
 
   repeat?: {
     /**
@@ -116,24 +128,6 @@ export interface BaseEnqueueJobOpts {
     cron?: string;
   };
 }
-
-export interface DelayedEnqueueJobOpts extends BaseEnqueueJobOpts {
-  /**
-   * Will delay the job's execution by the specified amount of milliseconds.
-   * Supports human-readable notation as of @see https://github.com/vercel/ms.
-   * If used together with `repeat`, this will delay the first job to be executed.
-   */
-  delay?: number | string;
-}
-
-export interface ScheduledEnqueueJobOpts extends BaseEnqueueJobOpts {
-  /**
-   * Schedules the job for execution at the specified timestamp.
-   */
-  runAt?: Date;
-}
-
-export type EnqueueJobOpts = DelayedEnqueueJobOpts | ScheduledEnqueueJobOpts;
 
 export interface Job extends Omit<JobDTO, "runAt" | "body"> {
   /**

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -95,6 +95,14 @@ export interface EnqueueJobOpts {
   exclusive?: boolean;
 
   /**
+   * Determines what to do when a job
+   * with the same ID already exists.
+   * false: do nothing (default)
+   * true: replace the job
+   */
+  override?: boolean;
+
+  /**
    * Will delay the job's execution by the specified amount of milliseconds.
    * Supports human-readable notation as of @see https://github.com/vercel/ms.
    * If used together with `repeat`, this will delay the first job to be executed.


### PR DESCRIPTION
This adds support for Owl's exclusive jobs as documented in https://github.com/quirrel-dev/owl/pull/9.