### PR TITLE
Add the Incident forwarder

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,7 +2,7 @@ import { createServer, QuirrelServerConfig } from "./scheduler";
 import { getLogger, LoggerType } from "./shared/logger";
 import { createWorker, QuirrelWorkerConfig } from "./worker";
 
-type QuirrelConfig = Omit<QuirrelServerConfig, "logger"> &
+export type QuirrelConfig = Omit<QuirrelServerConfig, "logger"> &
   Omit<QuirrelWorkerConfig, "enableUsageMetering" | "logger"> & {
     logger: LoggerType;
   };

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -8,6 +8,8 @@ const {
   PASSPHRASES,
   RUNNING_IN_DOCKER,
   DISABLE_TELEMETRY,
+  INCIDENT_RECEIVER_ENDPOINT,
+  INCIDENT_RECEIVER_PASSPHRASE,
 } = process.env;
 
 process.on("unhandledRejection", (reason, promise) => {
@@ -24,6 +26,12 @@ async function main() {
     runningInDocker: Boolean(RUNNING_IN_DOCKER),
     disableTelemetry: Boolean(DISABLE_TELEMETRY),
     logger: "structured",
+    incidentReceiver: INCIDENT_RECEIVER_ENDPOINT
+      ? {
+          endpoint: INCIDENT_RECEIVER_ENDPOINT,
+          passphrase: INCIDENT_RECEIVER_PASSPHRASE!,
+        }
+      : undefined,
   });
 
   async function teardown(signal: string) {

--- a/api/src/scheduler/jobs-repo.ts
+++ b/api/src/scheduler/jobs-repo.ts
@@ -3,7 +3,7 @@ import { POSTQueuesEndpointBody } from "./types/queues/POST/body";
 import {
   encodeQueueDescriptor,
   decodeQueueDescriptor,
-} from "../shared/http-job";
+} from "../shared/queue-descriptor";
 
 import * as uuid from "uuid";
 import { createOwl, cron } from "../shared/owl";

--- a/api/src/shared/incident-forwarder.ts
+++ b/api/src/shared/incident-forwarder.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+export class IncidentForwarder {
+  private axios;
+  constructor(incidentEndpoint: string, passphrase: string) {
+    this.axios = axios.create({
+      baseURL: incidentEndpoint,
+      headers: {
+        Authorization: `Bearer ${passphrase}`,
+      },
+    });
+  }
+
+  async dispatch(
+    job: {
+      tokenId: string;
+      id: string;
+      endpoint: string;
+      payload: string;
+      runAt: Date;
+    },
+    incident: { status: number; body: string }
+  ) {
+    try {
+      await this.axios.post("", {
+        type: "incident",
+        job,
+        incident,
+      });
+    } catch (error) {
+      console.error("Incident receiver is down: ", error);
+    }
+  }
+}

--- a/api/src/shared/queue-descriptor.ts
+++ b/api/src/shared/queue-descriptor.ts
@@ -1,18 +1,4 @@
-export const HTTP_JOB_QUEUE = "http";
-
 const delimiter = ";";
-
-interface RepeatOptions {
-  every?: number;
-  times?: number;
-  cron?: string;
-  count: number;
-}
-
-export interface HttpJob {
-  body?: string;
-  repeat?: RepeatOptions;
-}
 
 export function encodeQueueDescriptor(tokenId: string, endpoint: string) {
   return [tokenId, endpoint].map(encodeURIComponent).join(delimiter);

--- a/api/src/worker/index.ts
+++ b/api/src/worker/index.ts
@@ -7,6 +7,7 @@ import { Redis } from "ioredis";
 import { Telemetrist } from "../shared/telemetrist";
 import { createOwl } from "../shared/owl";
 import type { Logger } from "../shared/logger";
+import { IncidentForwarder } from "../shared/incident-forwarder";
 
 export function replaceLocalhostWithDockerHost(url: string): string {
   if (url.startsWith("http://localhost")) {
@@ -27,6 +28,7 @@ export interface QuirrelWorkerConfig {
   concurrency?: number;
   disableTelemetry?: boolean;
   logger?: Logger;
+  incidentReceiver?: { endpoint: string; passphrase: string };
 }
 
 export async function createWorker({
@@ -36,7 +38,15 @@ export async function createWorker({
   concurrency = 100,
   disableTelemetry,
   logger,
+  incidentReceiver,
 }: QuirrelWorkerConfig) {
+  const incidentForwarder = incidentReceiver
+    ? new IncidentForwarder(
+        incidentReceiver.endpoint,
+        incidentReceiver.passphrase
+      )
+    : undefined;
+
   const redisClient = redisFactory();
   const telemetrist = disableTelemetry
     ? undefined
@@ -51,52 +61,67 @@ export async function createWorker({
 
   const owl = createOwl(redisFactory);
 
-  const worker = owl.createWorker(
-    async (job) => {
-      let { tokenId, endpoint } = decodeQueueDescriptor(job.queue);
-      const body = job.payload;
+  const worker = owl.createWorker(async (job) => {
+    let { tokenId, endpoint } = decodeQueueDescriptor(job.queue);
+    const body = job.payload;
 
-      const executionDone = logger?.startingExecution({
-        tokenId,
-        endpoint,
-        body,
-        id: job.id,
-      });
+    const executionDone = logger?.startingExecution({
+      tokenId,
+      endpoint,
+      body,
+      id: job.id,
+    });
 
-      const headers: Record<string, string> = {
-        "Content-Type": "text/plain",
-      };
+    const headers: Record<string, string> = {
+      "Content-Type": "text/plain",
+    };
 
-      if (tokenId) {
-        const token = await tokenRepo.getById(tokenId);
-        if (token) {
-          const signature = sign(body ?? "", token);
-          headers["x-quirrel-signature"] = signature;
-        }
+    if (tokenId) {
+      const token = await tokenRepo.getById(tokenId);
+      if (token) {
+        const signature = sign(body ?? "", token);
+        headers["x-quirrel-signature"] = signature;
       }
+    }
 
-      if (runningInDocker) {
-        endpoint = replaceLocalhostWithDockerHost(endpoint);
-      }
+    if (runningInDocker) {
+      endpoint = replaceLocalhostWithDockerHost(endpoint);
+    }
 
-      await axios.post(endpoint, body, {
-        headers,
-      });
+    const response = await axios.post(endpoint, body, {
+      headers,
+      validateStatus: () => true,
+    });
 
-      await usageMeter?.record(tokenId);
-
+    if (response.status >= 200 && response.status < 300) {
       executionDone?.();
 
       telemetrist?.dispatch("dispatch_job");
-    },
-    (job, error) => {
-      const { endpoint, tokenId } = decodeQueueDescriptor(job.queue);
+    } else {
+      await incidentForwarder?.dispatch(
+        {
+          endpoint,
+          tokenId,
+          payload: job.payload,
+          id: job.id,
+          runAt: job.runAt,
+        },
+        {
+          body: response.data,
+          status: response.status,
+        }
+      );
+
       logger?.executionErrored(
         { endpoint, tokenId, body: job.payload, id: job.id },
-        error
+        response.data
       );
+
+      telemetrist?.dispatch("execution_errored");
     }
-  );
+
+    await usageMeter?.record(tokenId);
+  });
 
   async function close() {
     await worker.close();

--- a/api/src/worker/index.ts
+++ b/api/src/worker/index.ts
@@ -1,4 +1,4 @@
-import { decodeQueueDescriptor } from "../shared/http-job";
+import { decodeQueueDescriptor } from "../shared/queue-descriptor";
 import { UsageMeter } from "../shared/usage-meter";
 import axios from "axios";
 import { TokenRepo } from "../shared/token-repo";

--- a/api/src/worker/main.ts
+++ b/api/src/worker/main.ts
@@ -8,6 +8,8 @@ const {
   RUNNING_IN_DOCKER,
   CONCURRENCY,
   DISABLE_TELEMETRY,
+  INCIDENT_RECEIVER_ENDPOINT,
+  INCIDENT_RECEIVER_PASSPHRASE,
 } = process.env;
 
 process.on("unhandledRejection", (reason, promise) => {
@@ -23,6 +25,12 @@ async function main() {
     concurrency: Number.parseInt(CONCURRENCY ?? "") || 100,
     disableTelemetry: Boolean(DISABLE_TELEMETRY),
     logger: new StructuredLogger(),
+    incidentReceiver: INCIDENT_RECEIVER_ENDPOINT
+      ? {
+          endpoint: INCIDENT_RECEIVER_ENDPOINT,
+          passphrase: INCIDENT_RECEIVER_PASSPHRASE!,
+        }
+      : undefined,
   });
 
   async function teardown(signal: string) {

--- a/api/test/incident.test.ts
+++ b/api/test/incident.test.ts
@@ -1,0 +1,137 @@
+import { run } from "./runQuirrel";
+import fastify, { FastifyInstance } from "fastify";
+import delay from "delay";
+import type http from "http";
+import request from "supertest";
+
+function testAgainst(backend: "Redis" | "Mock") {
+  async function setup({ fail }: { fail: boolean }) {
+    const server = fastify();
+    server.post("/", () => {
+      throw new Error("Something broke!");
+    });
+
+    const endpoint = encodeURIComponent(await server.listen(0));
+
+    const incidentReceiverAuthorizations: any[] = [];
+    const incidentReceiverBodies: any[] = [];
+
+    const incidentReceiver = fastify();
+    incidentReceiver.post("/incident", (request, reply) => {
+      if (fail) {
+        reply.status(500).send();
+      } else {
+        incidentReceiverBodies.push(request.body);
+        incidentReceiverAuthorizations.push(request.headers.authorization);
+
+        reply.status(200).send();
+      }
+    });
+
+    const incidentReceiverEndpoint =
+      (await incidentReceiver.listen(0)) + "/incident";
+
+    const res = await run(backend, [], {
+      endpoint: incidentReceiverEndpoint,
+      passphrase: "super-secret",
+    });
+
+    const quirrel = res.server;
+    const teardown = res.teardown;
+
+    return {
+      quirrel,
+      endpoint,
+      incidentReceiverBodies,
+      incidentReceiverAuthorizations,
+      teardown: () =>
+        Promise.all([teardown(), server.close(), incidentReceiver.close()]),
+    };
+  }
+
+  describe(backend + " > incidents", () => {
+    test("are sent to the incident receiver", async () => {
+      const {
+        teardown,
+        quirrel,
+        endpoint,
+        incidentReceiverAuthorizations,
+        incidentReceiverBodies,
+      } = await setup({
+        fail: false,
+      });
+
+      const runAt = new Date().toISOString();
+
+      await request(quirrel)
+        .post("/queues/" + endpoint)
+        .send({
+          body: JSON.stringify({ foo: "bar" }),
+          id: "a",
+          runAt,
+        })
+        .expect(201);
+
+      await delay(50);
+
+      expect(incidentReceiverBodies).toEqual([
+        {
+          type: "incident",
+          incident: {
+            body: {
+              error: "Internal Server Error",
+              message: "Something broke!",
+              statusCode: 500,
+            },
+            status: 500,
+          },
+          job: {
+            endpoint: decodeURIComponent(endpoint),
+            id: "a",
+            payload: JSON.stringify({ foo: "bar" }),
+            runAt,
+            tokenId: "anonymous",
+          },
+        },
+      ]);
+      expect(incidentReceiverAuthorizations).toEqual(["Bearer super-secret"]);
+
+      await teardown();
+    });
+
+    describe("when the incident receiver is down", () => {
+      it("just continues normally", async () => {
+        const {
+          teardown,
+          quirrel,
+          endpoint,
+          incidentReceiverAuthorizations,
+          incidentReceiverBodies,
+        } = await setup({
+          fail: true,
+        });
+
+        const runAt = new Date().toISOString();
+
+        await request(quirrel)
+          .post("/queues/" + endpoint)
+          .send({
+            body: JSON.stringify({ foo: "bar" }),
+            id: "a",
+            runAt,
+          })
+          .expect(201);
+
+        await delay(50);
+
+        expect(incidentReceiverBodies).toEqual([]);
+        expect(incidentReceiverAuthorizations).toEqual([]);
+
+        await teardown();
+      });
+    });
+  });
+}
+
+testAgainst("Redis");
+testAgainst("Mock");

--- a/api/test/runQuirrel.ts
+++ b/api/test/runQuirrel.ts
@@ -1,7 +1,11 @@
-import { runQuirrel } from "../src";
+import { QuirrelConfig, runQuirrel } from "../src";
 import { createRedisFactory } from "../src/shared/create-redis";
 
-export async function run(backend: "Redis" | "Mock", passphrases?: string[]) {
+export async function run(
+  backend: "Redis" | "Mock",
+  passphrases?: string[],
+  incidentReceiver?: QuirrelConfig["incidentReceiver"]
+) {
   const redisFactory = createRedisFactory(
     backend === "Redis" ? process.env.REDIS_URL : undefined
   );
@@ -11,6 +15,7 @@ export async function run(backend: "Redis" | "Mock", passphrases?: string[]) {
     passphrases,
     disableTelemetry: true,
     logger: "none",
+    incidentReceiver,
   });
 
   const redis = redisFactory();


### PR DESCRIPTION
If a queue fails while processing a job, it just vanishes at the moment. We can do better than that!

This PR adds support for "incident forwarding", which basically means: Whenever an "incident" (read: queue handler returning non-200 code) occurs, it's forwarded to a specified HTTP endpoint.
For the hosted version, that endpoint would be part of the Quirrel Dashboard. For on-prem deployments, it could be some in-house error reporting tool.