### PR TITLE
Support root user impersonation

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -774,6 +774,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/basic-auth": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/basic-auth/-/basic-auth-1.1.3.tgz",
+      "integrity": "sha512-W3rv6J0IGlxqgE2eQ2pTb0gBjaGtejQpJ6uaCjz3UQ65+TFTPC5/lAE+POfx1YLdjtxvejJzsIAfd3MxWiVmfg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -27,6 +27,7 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
+    "@types/basic-auth": "^1.1.3",
     "@types/ioredis": "^4.17.7",
     "@types/jest": "^26.0.13",
     "@types/pino": "^6.3.3",
@@ -49,6 +50,7 @@
     "@sentry/node": "^5.26.0",
     "@sentry/tracing": "^5.26.0",
     "axios": "^0.20.0",
+    "basic-auth": "^2.0.1",
     "chalk": "^4.1.0",
     "commander": "^6.1.0",
     "cron-parser": "^2.16.3",

--- a/api/src/scheduler/index.ts
+++ b/api/src/scheduler/index.ts
@@ -82,7 +82,10 @@ export async function createServer({
   app.register(redisPlugin, { redisFactory });
   app.register(owlPlugin);
 
-  app.register(tokenAuthPlugin, { auth: enableAuth });
+  app.register(tokenAuthPlugin, {
+    auth: enableAuth,
+    passphrases: passphrases ?? [],
+  });
 
   if (!disableTelemetry) {
     app.register(telemetry, { runningInDocker });


### PR DESCRIPTION
In the hosted version, incidents are currently stored, but there's no way to recreate the jobs directly from the dashboard.
This PR adds support for "user impersonation", which allows the Dashboard to create jobs as if they were the original user themself.