### PR TITLE
Fix 49: Pin down Fastify to 3.9.2

### DIFF
--- a/development-ui/hooks/useQuirrel.tsx
+++ b/development-ui/hooks/useQuirrel.tsx
@@ -10,7 +10,6 @@ import { BaseLayout } from "../layouts/BaseLayout";
 import { QuirrelClient, Job } from "quirrel/client";
 import _ from "lodash";
 import { produce } from "immer";
-import delay from "delay";
 
 let alreadyAlerted = false;
 
@@ -371,7 +370,7 @@ export function QuirrelProvider(props: PropsWithChildren<{}>) {
         onActivity({ type: data[0], payload: data[1], date: Date.now() });
       };
     },
-    [dump, connectedSocket, quirrelClient.connectionWasAborted]
+    [dump, connectedSocket, quirrelClient.connectionWasAborted, onActivity]
   );
 
   const connect = useCallback(

--- a/quirrel/package-lock.json
+++ b/quirrel/package-lock.json
@@ -21,7 +21,7 @@
         "cron-parser": "^2.16.3",
         "cross-fetch": "^3.0.6",
         "easy-table": "^1.1.1",
-        "fastify": "^3.9.2",
+        "fastify": "3.9.2",
         "fastify-basic-auth": "^1.0.1",
         "fastify-blipp": "^3.0.0",
         "fastify-cors": "^4.1.0",

--- a/quirrel/package.json
+++ b/quirrel/package.json
@@ -68,7 +68,7 @@
     "cron-parser": "^2.16.3",
     "cross-fetch": "^3.0.6",
     "easy-table": "^1.1.1",
-    "fastify": "^3.9.2",
+    "fastify": "3.9.2",
     "fastify-basic-auth": "^1.0.1",
     "fastify-blipp": "^3.0.0",
     "fastify-cors": "^4.1.0",


### PR DESCRIPTION
Fastify 3.10 seems to have a regression when used with fastify-websockets.