### PR TITLE
Supply Job Metadata to Queue Handler

### DIFF
--- a/docs/docs/api/blitz.md
+++ b/docs/docs/api/blitz.md
@@ -10,7 +10,7 @@ import { Queue } from "quirrel/blitz";
 
 export default Queue(
     "api/someQueue",
-    async (job) => {
+    async (job, meta) => {
         // do something
     }
 );
@@ -24,7 +24,7 @@ Make sure to export it from an [API Route](https://blitzjs.com/docs/api-routes),
 ```ts
 function Queue<T>(
     path: string,
-    worker: (job: T): Promise<void>,
+    worker: (job: T, meta: JobMeta): Promise<void>,
     defaultJobOptions?: { exclusive?: boolean }
 ): QueueInstance<T>
 ```

--- a/docs/docs/api/express.md
+++ b/docs/docs/api/express.md
@@ -10,7 +10,7 @@ const app = Express()
 
 const someQueue = Queue(
   "someQueue",
-  async (job) => {
+  async (job, meta) => {
     // do something
   }
 )
@@ -28,7 +28,7 @@ Since there's no convention for Express's default development port, you'll have 
 ```ts
 function Queue<T>(
     path: string,
-    worker: (job: T): Promise<void>,
+    worker: (job: T, meta: JobMeta): Promise<void>,
     defaultJobOptions?: { exclusive?: boolean }
 ): QueueInstance<T>
 ```

--- a/docs/docs/api/next.md
+++ b/docs/docs/api/next.md
@@ -7,7 +7,7 @@ import { Queue } from "quirrel/next";
 
 export default Queue(
     "api/someQueue",
-    async (job) => {
+    async (job, meta) => {
         // do something
     }
 );
@@ -21,7 +21,7 @@ Make sure to export it from an [API Route](https://nextjs.org/docs/api-routes/in
 ```ts
 function Queue<T>(
     path: string,
-    worker: (job: T): Promise<void>,
+    worker: (job: T, meta: JobMeta): Promise<void>,
     defaultJobOptions?: { exclusive?: boolean }
 ): QueueInstance<T>
 ```

--- a/docs/docs/api/nuxt.md
+++ b/docs/docs/api/nuxt.md
@@ -7,7 +7,7 @@ import { Queue } from "quirrel/nuxt";
 
 export default Queue(
   "someQueue",
-  async (job) => {
+  async (job, meta) => {
     // do something
   }
 );
@@ -30,7 +30,7 @@ Make sure to export it from a [Server Middleware](https://nuxtjs.org/docs/2.x/co
 ```ts
 function Queue<T>(
     path: string,
-    worker: (job: T): Promise<void>,
+    worker: (job: T, meta: JobMeta): Promise<void>,
     defaultJobOptions?: { exclusive?: boolean }
 ): QueueInstance<T>
 ```

--- a/docs/docs/api/redwood.md
+++ b/docs/docs/api/redwood.md
@@ -7,7 +7,7 @@ import { Queue } from "quirrel/redwood";
 
 export const handler = Queue(
   "someQueue",
-  async (name) => {
+  async (job, meta) => {
     // do something
   }
 );
@@ -23,7 +23,7 @@ Make sure to export it from a [Serverless Function](https://redwoodjs.com/docs/s
 ```ts
 function Queue<T>(
     path: string,
-    worker: (job: T): Promise<void>,
+    worker: (job: T, meta: JobMeta): Promise<void>,
     defaultJobOptions?: { exclusive?: boolean }
 ): QueueInstance<T>
 ```

--- a/docs/docs/api/vercel.md
+++ b/docs/docs/api/vercel.md
@@ -7,7 +7,7 @@ import { Queue } from "quirrel/vercel";
 
 export default Queue(
   "api/someQueue",
-  async (job) => {
+  async (job, meta) => {
     // do something
   }
 );
@@ -21,7 +21,7 @@ Make sure to export it from a [Serverless Function](https://vercel.com/docs/serv
 ```ts
 function Queue<T>(
     path: string,
-    worker: (job: T): Promise<void>,
+    worker: (job: T, meta: JobMeta): Promise<void>,
     defaultJobOptions?: { exclusive?: boolean }
 ): QueueInstance<T>
 ```

--- a/quirrel/package-lock.json
+++ b/quirrel/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "quirrel",
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@quirrel/owl": "^0.8.0",
+        "@quirrel/owl": "^0.9.0",
         "@sentry/node": "6.2.0",
         "@sentry/tracing": "6.2.0",
         "basic-auth": "2.0.1",
@@ -794,7 +793,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1059,9 +1057,9 @@
       }
     },
     "node_modules/@quirrel/owl": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.8.0.tgz",
-      "integrity": "sha512-3Q92qlvyJOiLPH1eYtO5ilIeCjn9fiPsNgICkOQmqfxiV3uKpsVM06DrhM/ASxGxs01uwM06bdp4tXp48kuarw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.9.0.tgz",
+      "integrity": "sha512-+kwLv92avpbY6zHYE8bjLvYMBZvB0Gz485Wk7AYLvQO1oD0NE+4uqukpJ558+3zVwFKN9ST1p8lLt+7JmD6PmA==",
       "dependencies": {
         "debug": "^4.3.1",
         "ioredis": "^4.22.0",
@@ -2478,7 +2476,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3530,8 +3527,7 @@
       "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.1.tgz",
       "integrity": "sha512-C9Lvm0WFcn2RgxbMnTbXZenMIWcBtkzMr+dWqq/JsVoGFSVUVlPqeOa5LP5kM0I3zoOazFpckOEb2/0LDFfToQ==",
       "dependencies": {
-        "ansi-regex": "^3.0.0",
-        "wcwidth": ">=1.0.1"
+        "ansi-regex": "^3.0.0"
       },
       "optionalDependencies": {
         "wcwidth": ">=1.0.1"
@@ -3774,8 +3770,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5771,7 +5766,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -6917,7 +6911,6 @@
         "raw-body": "2.4.1",
         "react-is": "16.13.1",
         "react-refresh": "0.8.3",
-        "sharp": "0.26.3",
         "stream-browserify": "3.0.0",
         "styled-jsx": "3.3.2",
         "use-subscription": "1.5.1",
@@ -11889,9 +11882,9 @@
       "dev": true
     },
     "@quirrel/owl": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.8.0.tgz",
-      "integrity": "sha512-3Q92qlvyJOiLPH1eYtO5ilIeCjn9fiPsNgICkOQmqfxiV3uKpsVM06DrhM/ASxGxs01uwM06bdp4tXp48kuarw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.9.0.tgz",
+      "integrity": "sha512-+kwLv92avpbY6zHYE8bjLvYMBZvB0Gz485Wk7AYLvQO1oD0NE+4uqukpJ558+3zVwFKN9ST1p8lLt+7JmD6PmA==",
       "requires": {
         "debug": "^4.3.1",
         "ioredis": "^4.22.0",

--- a/quirrel/package.json
+++ b/quirrel/package.json
@@ -57,7 +57,7 @@
     "websocket": "^1.0.33"
   },
   "dependencies": {
-    "@quirrel/owl": "^0.8.0",
+    "@quirrel/owl": "^0.9.0",
     "@sentry/node": "6.2.0",
     "@sentry/tracing": "6.2.0",
     "basic-auth": "2.0.1",

--- a/quirrel/src/api/worker/index.ts
+++ b/quirrel/src/api/worker/index.ts
@@ -83,6 +83,13 @@ export async function createWorker({
 
       const headers: Record<string, string> = {
         "Content-Type": "text/plain",
+        "x-quirrel-meta": JSON.stringify({
+          id: job.id,
+          count: job.count,
+          exclusive: job.exclusive,
+          retry: job.retry,
+          nextRepetition: jobMeta.nextExecDate,
+        }),
       };
 
       if (tokenId) {

--- a/quirrel/src/client/index.ts
+++ b/quirrel/src/client/index.ts
@@ -13,6 +13,10 @@ export { Job };
 
 export interface JobMeta {
   id: string;
+  count: number;
+  exclusive: boolean;
+  nextRepetition?: Date;
+  retry: number[];
 }
 
 export type QuirrelJobHandler<T> = (job: T, meta: JobMeta) => Promise<void>;
@@ -465,13 +469,19 @@ export class QuirrelClient<T> {
     }
 
     const payload = await this.decryptAndDecodeBody(body);
-    const { id } = JSON.parse((headers["x-quirrel-meta"] as string) ?? "{}");
+    const { id, count, retry, nextRepetition, exclusive } = JSON.parse(
+      (headers["x-quirrel-meta"] as string) ?? "{}"
+    );
 
     console.log(`Received job to ${this.route}: `, payload);
 
     try {
       await this.handler(payload, {
         id,
+        count,
+        retry,
+        nextRepetition,
+        exclusive,
       });
 
       return {

--- a/quirrel/src/client/index.ts
+++ b/quirrel/src/client/index.ts
@@ -11,12 +11,12 @@ import pack from "../../package.json";
 
 export { Job };
 
-export interface JobMeta {
-  id: string;
-  count: number;
-  exclusive: boolean;
-  nextRepetition?: Date;
-  retry: number[];
+export interface JobMeta
+  extends Pick<JobDTO, "id" | "count" | "exclusive" | "retry"> {
+  /**
+   * If this is a repeated job, the next repetition will be scheduled for this Date.
+   */
+  readonly nextRepetition?: Date;
 }
 
 export type QuirrelJobHandler<T> = (job: T, meta: JobMeta) => Promise<void>;

--- a/quirrel/src/client/test/encryption.test.ts
+++ b/quirrel/src/client/test/encryption.test.ts
@@ -59,6 +59,10 @@ test("encryption", async () => {
   expect(jobMetadata).toEqual([
     {
       id: job.id,
+      count: 1,
+      exclusive: false,
+      nextRepetition: undefined,
+      retry: [],
     },
   ]);
 

--- a/quirrel/src/client/test/encryption.test.ts
+++ b/quirrel/src/client/test/encryption.test.ts
@@ -1,4 +1,4 @@
-import { QuirrelClient } from "..";
+import { JobMeta, QuirrelClient } from "..";
 import { run } from "../../api/test/runQuirrel";
 import * as http from "http";
 import delay from "delay";
@@ -9,6 +9,7 @@ test("encryption", async () => {
 
   const encryptedBodies: string[] = [];
   const decryptedBodies: string[] = [];
+  const jobMetadata: JobMeta[] = [];
 
   let quirrel: QuirrelClient<any>;
 
@@ -30,7 +31,8 @@ test("encryption", async () => {
     .listen(0);
 
   quirrel = new QuirrelClient({
-    async handler(body) {
+    async handler(body, meta) {
+      jobMetadata.push(meta);
       decryptedBodies.push(body);
     },
     route: "/lol",
@@ -54,6 +56,11 @@ test("encryption", async () => {
   expect(encryptedBodies).toHaveLength(1);
   expect(encryptedBodies[0].startsWith("ddb7:")).toBe(true);
   expect(decryptedBodies).toEqual(["hello world"]);
+  expect(jobMetadata).toEqual([
+    {
+      id: job.id,
+    },
+  ]);
 
   server.teardown();
   endpoint.close();

--- a/quirrel/src/connect.ts
+++ b/quirrel/src/connect.ts
@@ -63,7 +63,7 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: string,
-  handler: QuirrelJobHandler<void>
+  handler: () => Promise<void>
 ) {
   return Queue(route, handler) as unknown;
 }

--- a/quirrel/src/next.ts
+++ b/quirrel/src/next.ts
@@ -14,11 +14,14 @@ registerDevelopmentDefaults({
   applicationBaseUrl: "http://localhost:3000",
 });
 
-export type Queue<Payload> = Omit<QuirrelClient<Payload>, "respondTo" | "makeRequest">;
+export type Queue<Payload> = Omit<
+  QuirrelClient<Payload>,
+  "respondTo" | "makeRequest"
+>;
 
 export function Queue<Payload>(
   route: string,
-  handler: (payload: Payload) => Promise<void>,
+  handler: QuirrelJobHandler<Payload>,
   defaultJobOptions?: DefaultJobOptions
 ): Queue<Payload> {
   const quirrel = new QuirrelClient<Payload>({
@@ -53,7 +56,7 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: string,
-  handler: QuirrelJobHandler<void>
+  handler: () => Promise<void>
 ) {
   return Queue(route, handler) as unknown;
 }

--- a/quirrel/src/nuxt.ts
+++ b/quirrel/src/nuxt.ts
@@ -22,7 +22,7 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: string,
-  handler: connect.QuirrelJobHandler<void>
+  handler: () => Promise<void>
 ) {
   return Queue(route, handler) as unknown;
 }

--- a/quirrel/src/redwood.ts
+++ b/quirrel/src/redwood.ts
@@ -24,7 +24,10 @@ interface RedwoodResponse {
   headers: Record<string, string>;
 }
 
-export type Queue<Payload> = Omit<QuirrelClient<Payload>, "respondTo" | "makeRequest">;
+export type Queue<Payload> = Omit<
+  QuirrelClient<Payload>,
+  "respondTo" | "makeRequest"
+>;
 
 export function Queue<Payload>(
   route: string,
@@ -66,7 +69,7 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: string,
-  handler: QuirrelJobHandler<void>
+  handler: () => Promise<void>
 ) {
   return Queue(route, handler) as unknown;
 }


### PR DESCRIPTION
This PR adds a second parameter to the job processor:

```ts
Queue(
  ...,
  async (job, { id, exclusive, retry, ... } /* 👈 */) => {
    // ...
  }
)
```