### PR TITLE
Add extra information for self hosting

### DIFF
--- a/docs/docs/deploying.md
+++ b/docs/docs/deploying.md
@@ -36,6 +36,8 @@ created on, excluding them from future bugfixes.
 
 For most people, the [hosted version](https://quirrel.dev) of Quirrel is the easiest, and probably also cheapest way of using Quirrel (there's a free tier if your project is just starting out, and OSS and side projects can apply for discounts).
 
-If you still want to host Quirrel yourself, you can do so using the [Docker Image](https://github.com/orgs/quirrel-dev/packages/container/package/quirrel).
-This requires you to set the `QUIRREL_URL` variable to the location of your deployment (it defaults to `https://api.quirrel.dev`).
-The `QUIRREL_TOKEN` can be obtained using the server's [REST API](https://api.quirrel.dev/documentation/index.html#/default/put_tokens__id_).
+If you still want to host Quirrel yourself, you can do so using the [Docker Image](https://github.com/orgs/quirrel-dev/packages/container/package/quirrel). `REDIS_URL` should be set to a Redis connection string. For production deployments, `PASSPHRASES` should be set to a `:`-separated list of passphrases used for securing the token endpoints. Additionally, the deployment should be secured using HTTPS.
+
+Using self-hosted Quirrel requires you to set the `QUIRREL_URL` variable to the location of your deployment (it defaults to `https://api.quirrel.dev`).
+The `QUIRREL_TOKEN` can be obtained using the server's [REST API](https://api.quirrel.dev/documentation/index.html#/default/put_tokens__id_). If a passphrase was set, it must be passed in using basic authentication.
+


### PR DESCRIPTION
Overall, I found self-hosting to be pretty straightforward. I added a couple points that were discussed in #187, as well as information about authentication because the generated swagger doc doesn't have details about that for some reason.