### PR TITLE
Connect Owl's Opentracing to Datadog Tracer

### DIFF
--- a/quirrel/package-lock.json
+++ b/quirrel/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@quirrel/owl": "^0.11.0",
+        "@quirrel/owl": "^0.12.0",
         "@sentry/node": "6.5.1",
         "@sentry/tracing": "6.5.1",
         "basic-auth": "2.0.1",
@@ -38,6 +38,7 @@
         "jsonwebtoken": "^8.5.1",
         "ms": "2.1.3",
         "open": "8.2.0",
+        "opentracing": "^0.14.5",
         "parse-gitignore": "1.0.1",
         "pino": "6.11.3",
         "plausible-telemetry": "0.1.0",
@@ -1014,13 +1015,14 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@quirrel/owl": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.11.0.tgz",
-      "integrity": "sha512-bqUXdhfyhQFtcGuNijZYWzeU1hFOLkSMEdv036C9wV6PlIQKu/6o6q972WGfCxIahAdSHECMAhl6a8dgc5Rf5A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.12.0.tgz",
+      "integrity": "sha512-RbTFMuHd2gB+epZxcTtWoBpGtoYWJB5w5+OhBPDxV2x/QUdWgVLsESQXrNkc5316K0alGhzjy6o0dzZcCLMAxg==",
       "dependencies": {
         "debug": "^4.3.1",
         "ioredis": "^4.27.1",
-        "ioredis-mock": "^5.5.6"
+        "ioredis-mock": "^5.5.6",
+        "opentracing": "^0.14.5"
       }
     },
     "node_modules/@sentry/core": {
@@ -9964,13 +9966,14 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@quirrel/owl": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.11.0.tgz",
-      "integrity": "sha512-bqUXdhfyhQFtcGuNijZYWzeU1hFOLkSMEdv036C9wV6PlIQKu/6o6q972WGfCxIahAdSHECMAhl6a8dgc5Rf5A==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.12.0.tgz",
+      "integrity": "sha512-RbTFMuHd2gB+epZxcTtWoBpGtoYWJB5w5+OhBPDxV2x/QUdWgVLsESQXrNkc5316K0alGhzjy6o0dzZcCLMAxg==",
       "requires": {
         "debug": "^4.3.1",
         "ioredis": "^4.27.1",
-        "ioredis-mock": "^5.5.6"
+        "ioredis-mock": "^5.5.6",
+        "opentracing": "^0.14.5"
       }
     },
     "@sentry/core": {

--- a/quirrel/package.json
+++ b/quirrel/package.json
@@ -64,7 +64,7 @@
     "websocket": "^1.0.33"
   },
   "dependencies": {
-    "@quirrel/owl": "^0.11.0",
+    "@quirrel/owl": "^0.12.0",
     "@sentry/node": "6.5.1",
     "@sentry/tracing": "6.5.1",
     "basic-auth": "2.0.1",
@@ -94,6 +94,7 @@
     "jsonwebtoken": "^8.5.1",
     "ms": "2.1.3",
     "open": "8.2.0",
+    "opentracing": "^0.14.5",
     "parse-gitignore": "1.0.1",
     "pino": "6.11.3",
     "plausible-telemetry": "0.1.0",

--- a/quirrel/src/api/shared/tracer.ts
+++ b/quirrel/src/api/shared/tracer.ts
@@ -1,8 +1,13 @@
-import tracer from "dd-trace";
+import ddTrace from "dd-trace";
+import opentracing from "opentracing";
 
 module.exports = (serviceName: string = "quirrel") => {
-  return tracer.init({
+  const tracer = ddTrace.init({
     enabled: process.env.DD_TRACE_ENABLED === "true",
     service: serviceName,
   });
+
+  opentracing.initGlobalTracer(tracer);
+
+  return tracer;
 };

--- a/quirrel/src/api/worker/index.ts
+++ b/quirrel/src/api/worker/index.ts
@@ -65,7 +65,7 @@ export async function createWorker({
 
   const owl = await createOwl(redisFactory, incidentReceiver, telemetrist);
 
-  const worker = await owl.createWorker(async (job, ack) => {
+  const worker = await owl.createWorker(async (job, ack, span) => {
     let { tokenId, endpoint } = decodeQueueDescriptor(job.queue);
     const body = job.payload;
 
@@ -120,7 +120,7 @@ export async function createWorker({
 
       telemetrist?.dispatch("dispatch_job");
 
-      await worker.acknowledger.acknowledge(ack);
+      await worker.acknowledger.acknowledge(ack, undefined, span);
     } else {
       const responseBody = await response.text();
 


### PR DESCRIPTION
Owl added support for OpenTracing, which allows performance & behaviour to be monitored more accurately than just via Datadog's plugin-driven tracing. This PR sets OpenTracing up with the Datadog client.