### PR TITLE
Don't publish unneeded files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "module": "CommonJS",
     "moduleResolution": "node"
   },
-  "exclude": ["dist", "./*.d.ts", "development-ui", "examples"]
+  "include": ["src"],
 }


### PR DESCRIPTION
v1.6.2 accidentally published some compiled files from the `examples` folder. This PR makes sure only files from `src` are compiled.