### PR TITLE
Documents the retry queue option limits

### DIFF
--- a/docs/docs/api/queue.md
+++ b/docs/docs/api/queue.md
@@ -111,6 +111,8 @@ Retries a jobs three times, until it successd: After 10 seconds, 5 minutes and 1
 
 You can also specify `{ retry: [ ... ] }` as the third argument to the `Queue` constructor.
 
+> Currently, there's a hard limit of 10 retry attempts.
+
 ### `.enqueueMany`
 
 ```ts


### PR DESCRIPTION
I found an undocumented limit in the Queue retry option (set to 10 retries). I think it would be great to mention this limit in the documentation.

https://github.com/quirrel-dev/quirrel/blob/main/src/client/index.ts#L110


