### PR TITLE
fix: add env node to bin file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,1 +1,2 @@
+#!/usr/bin/env node
 require("./dist/cjs/src/cli/index");


### PR DESCRIPTION
currently the bin file is not working. looks like a change in the most recent version.

```
❯ ./node_modules/.bin/quirrel ci
./node_modules/.bin/quirrel: line 1: syntax error near unexpected token `"./dist/cjs/src/cli/index"'
./node_modules/.bin/quirrel: line 1: `require("./dist/cjs/src/cli/index");'
```