### PR TITLE
Use official ioredis-mock again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "quirrel",
       "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.14.7",
         "@babel/traverse": "^7.14.7",
-        "@quirrel/ioredis-mock": "^5.6.1",
         "@quirrel/owl": "^0.14.3",
         "@sentry/node": "6.13.3",
         "@sentry/tracing": "6.13.3",
@@ -38,6 +36,7 @@
         "fastify-swagger": "^4.5.0",
         "fastify-websocket": "4.0.0",
         "ioredis": "4.28.0",
+        "ioredis-mock": "^5.6.1",
         "ipaddr.js": "^2.0.1",
         "js-yaml": "^4.1.0",
         "jsonwebtoken": "^8.5.1",
@@ -1091,24 +1090,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
-    },
-    "node_modules/@quirrel/ioredis-mock": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@quirrel/ioredis-mock/-/ioredis-mock-5.6.1.tgz",
-      "integrity": "sha512-S66lITLabNKjBA/QqCrAJDU4mbeKvwmGJuyiQlnQjdw5tTBRZLZ8uKJo3/DIDT5IGTgYJz0aTPX7CyXtq8pbEA==",
-      "dependencies": {
-        "fengari": "^0.1.4",
-        "fengari-interop": "^0.1.2",
-        "lodash": "^4.17.21",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "ioredis": "4.x",
-        "redis-commands": "1.x"
-      }
     },
     "node_modules/@quirrel/owl": {
       "version": "0.14.3",
@@ -3815,9 +3796,9 @@
       }
     },
     "node_modules/ioredis-mock": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.6.0.tgz",
-      "integrity": "sha512-Ow+tyKdijg/gA2gSEv7lq8dLp6bO7FnwDXbJ9as37NF23XNRGMLzBc7ITaqMydfrbTodWnLcE2lKEaBs7SBpyA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.6.1.tgz",
+      "integrity": "sha512-y04QhRa77ODKc/qwTr4GZ7xzLeJDMRRJPj0jslbcQpsh/OubQKe/FxeZ+nwakj1gWMke23H8QBICOCgTfuSP0A==",
       "dependencies": {
         "fengari": "^0.1.4",
         "fengari-interop": "^0.1.2",
@@ -8270,17 +8251,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
-    "@quirrel/ioredis-mock": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@quirrel/ioredis-mock/-/ioredis-mock-5.6.1.tgz",
-      "integrity": "sha512-S66lITLabNKjBA/QqCrAJDU4mbeKvwmGJuyiQlnQjdw5tTBRZLZ8uKJo3/DIDT5IGTgYJz0aTPX7CyXtq8pbEA==",
-      "requires": {
-        "fengari": "^0.1.4",
-        "fengari-interop": "^0.1.2",
-        "lodash": "^4.17.21",
-        "standard-as-callback": "^2.1.0"
-      }
-    },
     "@quirrel/owl": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@quirrel/owl/-/owl-0.14.3.tgz",
@@ -10525,9 +10495,9 @@
       }
     },
     "ioredis-mock": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.6.0.tgz",
-      "integrity": "sha512-Ow+tyKdijg/gA2gSEv7lq8dLp6bO7FnwDXbJ9as37NF23XNRGMLzBc7ITaqMydfrbTodWnLcE2lKEaBs7SBpyA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.6.1.tgz",
+      "integrity": "sha512-y04QhRa77ODKc/qwTr4GZ7xzLeJDMRRJPj0jslbcQpsh/OubQKe/FxeZ+nwakj1gWMke23H8QBICOCgTfuSP0A==",
       "requires": {
         "fengari": "^0.1.4",
         "fengari-interop": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "dependencies": {
     "@babel/parser": "^7.14.7",
     "@babel/traverse": "^7.14.7",
-    "@quirrel/ioredis-mock": "^5.6.1",
     "@quirrel/owl": "^0.14.3",
     "@sentry/node": "6.13.3",
     "@sentry/tracing": "6.13.3",
@@ -94,6 +93,7 @@
     "fastify-swagger": "^4.5.0",
     "fastify-websocket": "4.0.0",
     "ioredis": "4.28.0",
+    "ioredis-mock": "^5.6.1",
     "ipaddr.js": "^2.0.1",
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/api/shared/create-redis.ts
+++ b/src/api/shared/create-redis.ts
@@ -1,9 +1,9 @@
 import IORedis from "ioredis";
-import IORedisMock from "@quirrel/ioredis-mock";
+import IORedisMock from "ioredis-mock";
 
 export function createRedisFactory(redisUrl?: string): () => IORedis.Redis {
   if (!redisUrl) {
-    let redis: any | undefined = undefined;
+    let redis: IORedisMock | undefined = undefined;
     return () => {
       if (!redis) {
         redis = new IORedisMock();

--- a/src/api/shared/ioredis.d.ts
+++ b/src/api/shared/ioredis.d.ts
@@ -1,4 +1,4 @@
-declare module "@quirrel/ioredis-mock" {
+declare module "ioredis-mock" {
   import { Redis } from "ioredis";
   class RedisMock extends Redis {
     createConnectedClient(): RedisMock;

--- a/src/api/shared/usage-meter.ts
+++ b/src/api/shared/usage-meter.ts
@@ -1,5 +1,5 @@
 import type { Redis } from "ioredis";
-import RedisMock from "@quirrel/ioredis-mock";
+import RedisMock from "ioredis-mock";
 
 export class UsageMeter {
   constructor(private readonly redis: Redis) {}


### PR DESCRIPTION
Since https://github.com/stipsan/ioredis-mock/pull/1092 has been merged, we don't need to use the fork anymore.