### PR TITLE
add dx error: override requires id

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -313,6 +313,10 @@ export class QuirrelClient<T> {
       throw new Error("retry and repeat cannot be used together");
     }
 
+    if (options.override && !options.id) {
+      throw new Error("override requires id");
+    }
+
     options = EnqueueJobOptionsSchema.parse(options);
 
     let delay = parseDuration(options.delay);

--- a/src/client/test/dx.test.ts
+++ b/src/client/test/dx.test.ts
@@ -63,4 +63,14 @@ describe("DX", () => {
       ).rejects.toThrowError("retry and repeat cannot be used together");
     });
   });
+
+  describe("when overriding without id", () => {
+    it("throws immediately", async () => {
+      await expect(() =>
+        quirrel.enqueue("", {
+          override: true,
+        })
+      ).rejects.toThrowError("override requires id");
+    });
+  });
 });


### PR DESCRIPTION
today's incident was caused by a rouge application creating thousands of jobs b/c they put "override: true" without an ID. that's unintended behaviour, let's make sure people see an error client-side if they're doing that.