### PR TITLE
migration: add support for more than .enqueue

### DIFF
--- a/docs/docs/migrating-servers.md
+++ b/docs/docs/migrating-servers.md
@@ -11,8 +11,7 @@ This will result in the old instance slowly draining.
 Once it's fully drained, the migration is complete.
 
 :::warning
-At the moment, this migration *does not* work fully for applications that use `.get`, `.getById`, `.invoke`, `.delete`, `override: true` or `exclusive` jobs.
-A solution for these applications is under active development.
+During the migration, the `exclusive` jobs feature will not work perfectly.
 If that's a problem for your application, [get in touch](mailto:migration@quirrel.dev).
 :::
 
@@ -30,6 +29,6 @@ Here's the step-by-step guide:
   Cron Jobs are transferred on the first run of `quirrel ci`.
 
 4. Use the `Stats` page on [https://ui.quirrel.dev](https://ui.quirrel.dev/) to watch the old instance drain fully. Depending on your application, this can take weeks.
-5. After the old instance is fully drained, remove the `QUIRREL_MIGRATE` environment variables.
+5. After the old instance is fully drained, remove the `QUIRREL_MIGRATE_*` environment variables.
 
 If you face an issue, please [open an issue](https://github.com/quirrel-dev/quirrel/issues/new/choose) on GitHub or [email Simon](mailto:migration@quirrel.dev).

--- a/src/client/test/migration.test.ts
+++ b/src/client/test/migration.test.ts
@@ -1,5 +1,7 @@
 import { QuirrelClient } from "..";
 import { symmetric } from "secure-webhooks";
+import { run } from "../../api/test/runQuirrel";
+import { getAddress } from "./util";
 
 test("migration", async () => {
   process.env.NODE_ENV = "production";
@@ -28,4 +30,132 @@ test("migration", async () => {
   expect(await requestWith(newToken)).toBe(200);
   expect(await requestWith(oldToken)).toBe(200);
   expect(await requestWith("wrong token")).toBe(401);
+});
+
+test("migration read + write", async () => {
+  const passphrase = "password";
+  const appId = "migration-test";
+  const oldServer = await run("Mock", {
+    passphrases: [passphrase],
+  });
+  const newServer = await run("Mock", {
+    passphrases: [passphrase],
+  });
+
+  const oldToken = await oldServer.app.app.tokens?.create(appId);
+  const newToken = await newServer.app.app.tokens?.create(appId);
+  expect(oldToken).toBeDefined();
+  expect(newToken).toBeDefined();
+
+  const oldClient = new QuirrelClient({
+    handler: async () => {},
+    route: "",
+    config: {
+      token: oldToken,
+      quirrelBaseUrl: getAddress(oldServer.server),
+      applicationBaseUrl: "unused",
+    },
+  });
+
+  const newClient = new QuirrelClient({
+    handler: async () => {},
+    route: "",
+    config: {
+      token: newToken,
+      oldToken,
+      quirrelBaseUrl: getAddress(newServer.server),
+      quirrelOldBaseUrl: getAddress(oldServer.server),
+      applicationBaseUrl: "unused",
+    },
+  });
+
+  // get: should iterate through both
+  const jobAOnOld = await oldClient.enqueue("a", {
+    delay: "1h",
+  });
+  await newClient.enqueue("b", {
+    delay: "1h",
+  });
+  const allJobs = [];
+  for await (const jobs of newClient.get()) {
+    allJobs.push(...jobs);
+  }
+  expect(allJobs).toHaveLength(2);
+
+  // .getById should look at old
+  expect(await newClient.getById(jobAOnOld.id)).toBeTruthy();
+
+  // override: false. if job already exists on old instance, let it stay there
+  await oldClient.enqueue("old payload", {
+    id: "foo",
+    delay: "1h",
+  });
+  const jobThatAlreadyExists = await newClient.enqueue("new payload", {
+    id: "foo",
+    delay: "1h",
+  });
+  expect(jobThatAlreadyExists.body).toEqual("old payload");
+
+  const jobThatAlreadyExistsOnNew = await (newClient as any).fetchAgainstCurrent(
+    "/foo"
+  );
+  expect(jobThatAlreadyExistsOnNew.status).toBe(404);
+
+  // override: false. if job doesn't exist on old instance, it should be on new
+  await newClient.enqueue("new payload", {
+    id: "override-false-on-new",
+    delay: "1h",
+  });
+  const jobOnNew = await (newClient as any).fetchAgainstCurrent(
+    "/override-false-on-new"
+  );
+  expect(jobOnNew.status).toBe(200);
+
+  // override: true. if job already exists on old instance, it should be deleted
+  await oldClient.enqueue("old payload", {
+    id: "override-true",
+    delay: "1h",
+  });
+  await newClient.enqueue("new payload", {
+    id: "override-true",
+    delay: "1h",
+    override: true,
+  });
+  expect(
+    (await (oldClient as any).fetchAgainstCurrent("/override-true")).status
+  ).toBe(404);
+  expect(
+    (await (newClient as any).fetchAgainstCurrent("/override-true")).status
+  ).toBe(200);
+
+  // delete: should run against both instances
+  await oldClient.enqueue("old payload", {
+    id: "delete",
+    delay: "1h",
+  });
+  expect(await newClient.delete("delete")).toBe(true);
+  expect(await oldClient.getById("delete")).toBeNull();
+
+  await newClient.enqueue("new payload", {
+    id: "delete",
+    delay: "1h",
+  });
+  expect(await newClient.delete("delete")).toBe(true);
+  expect(await newClient.getById("delete")).toBeNull();
+
+  // invoke: should look at both instances
+  await oldClient.enqueue("", {
+    id: "invoke",
+    delay: "1h",
+  });
+  expect(await newClient.invoke("invoke")).toBe(true);
+
+  await newClient.enqueue("", {
+    id: "invoke-2",
+    delay: "1h",
+  });
+  expect(await newClient.invoke("invoke-2")).toBe(true);
+
+  await oldServer.teardown();
+  await newServer.teardown();
 });


### PR DESCRIPTION
This PR adds migration support for features like `.invoke`, `override:`, `.delete` or `.get`.