### PR TITLE
fix: export types NextApiRequest and NextApiResponse

### DIFF
--- a/src/next.ts
+++ b/src/next.ts
@@ -9,12 +9,12 @@ import {
 import { registerDevelopmentDefaults } from "./client/config";
 import type { IncomingHttpHeaders } from "http";
 
-interface NextApiRequest {
+export interface NextApiRequest {
   body: any;
   headers: IncomingHttpHeaders;
 }
 
-interface NextApiResponse {
+export interface NextApiResponse {
   setHeader(key: string, value: string): void;
   status(code: number): void;
   send(body: string): void;

--- a/src/next.ts
+++ b/src/next.ts
@@ -20,7 +20,7 @@ export interface NextApiResponse {
   send(body: string): void;
 }
 
-type NextApiHandler = (
+export type NextApiHandler = (
   req: NextApiRequest,
   res: NextApiResponse
 ) => void | Promise<void>;


### PR DESCRIPTION
when using this in a project that has `"declaration": true` in its tsconfig, I'm hitting 

```
src/queue/mailQueue.ts(7,7): error TS4023: Exported variable 'queue' has or is using name 'NextApiRequest' from external module "node_modules/quirrel/dist/esm/src/next" but cannot be named.
src/queue/mailQueue.ts(7,7): error TS4023: Exported variable 'queue' has or is using name 'NextApiResponse' from external module "node_modules/quirrel/dist/esm/src/next" but cannot be named.
```

If I understand google correctly, exporting those should do? not entirely sure.