### PR TITLE
feat: allow passing a logger function to quirrel client

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -40,8 +40,7 @@ export type DefaultJobOptions = Pick<EnqueueJobOptions, "exclusive" | "retry">;
 interface CreateQuirrelClientArgs<T> {
   route: string;
   handler: QuirrelJobHandler<T>;
-  logger?: CustomLogger<T>;
-  defaultJobOptions?: DefaultJobOptions;
+  options?: QuirrelOptions<T>;
   config?: {
     /**
      * Recommended way to set this: process.env.QUIRREL_BASE_URL
@@ -258,6 +257,10 @@ function getAuthHeaders(
   return { Authorization: `Bearer ${token}` };
 }
 
+export interface QuirrelOptions<T = unknown> extends DefaultJobOptions {
+  logger?: CustomLogger<T>;
+}
+
 export class QuirrelClient<T> {
   private handler;
   private route;
@@ -277,7 +280,7 @@ export class QuirrelClient<T> {
 
   constructor(args: CreateQuirrelClientArgs<T>) {
     this.handler = args.handler;
-    this.defaultJobOptions = args.defaultJobOptions;
+    this.defaultJobOptions = args.options;
 
     const token = args.config?.token ?? config.getQuirrelToken();
     this.defaultHeaders = {
@@ -285,7 +288,7 @@ export class QuirrelClient<T> {
       "X-QuirrelClient-Version": pack.version,
     };
 
-    this.logger = args.logger ?? defaultLogger;
+    this.logger = args.options?.logger ?? defaultLogger;
     const quirrelBaseUrl =
       args.config?.quirrelBaseUrl ?? config.getQuirrelBaseUrl();
     this.applicationBaseUrl = config.withoutTrailingSlash(

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -23,12 +23,12 @@ export interface JobMeta
   readonly nextRepetition?: Date;
 }
 
-export type CustomLogger<Payload = unknown> = {
+export type QuirrelLogger<Payload = unknown> = {
   receivedJob: (route: string, data: Payload) => void;
   processingError: (route: string, data: Payload, error: unknown) => void;
 };
 
-const defaultLogger: CustomLogger = {
+const defaultLogger: QuirrelLogger = {
   receivedJob: (route, data) => console.log(`Received job to ${route}`, data),
   processingError: (route, data, error) =>
     console.error(`Error in job at ${route}`, data, error),
@@ -258,7 +258,7 @@ function getAuthHeaders(
 }
 
 export interface QuirrelOptions<T = unknown> extends DefaultJobOptions {
-  logger?: CustomLogger<T>;
+  logger?: QuirrelLogger<T>;
 }
 
 export class QuirrelClient<T> {
@@ -276,7 +276,7 @@ export class QuirrelClient<T> {
   private fetch;
   private catchDecryptionErrors;
   private signaturePublicKey;
-  private logger: CustomLogger<T>;
+  private logger: QuirrelLogger<T>;
 
   constructor(args: CreateQuirrelClientArgs<T>) {
     this.handler = args.handler;

--- a/src/client/test/logger.test.ts
+++ b/src/client/test/logger.test.ts
@@ -1,0 +1,95 @@
+import { run } from "../../api/test/runQuirrel";
+import { getAddress, makeSignal } from "./util";
+import { QuirrelClient } from "..";
+import http from "http";
+
+const errorLogMock = jest.fn();
+const logMock = jest.fn();
+const receiverMock = jest.fn();
+
+global.console = {
+  ...global.console,
+  error: errorLogMock,
+  log: logMock,
+};
+
+describe("client logger", () => {
+  let quirrelBaseUrl: string;
+  let server: Awaited<ReturnType<typeof run>>;
+
+  beforeAll(async () => {
+    server = await run("Mock");
+    quirrelBaseUrl = getAddress(server.server);
+  });
+
+  afterAll(async () => {
+    server.teardown();
+  });
+
+  beforeEach(() => {
+    errorLogMock.mockReset();
+    logMock.mockReset();
+  });
+
+  it("works without passing a custom logger function", async () => {
+    const quirrel = new QuirrelClient<{ result: "success" | "fail" }>({
+      route: "routeName",
+      async handler(payload) {
+        if (payload.result === "fail") throw new Error("yey,errors");
+      },
+      config: {
+        quirrelBaseUrl,
+        applicationBaseUrl: "http://localhost",
+      },
+    });
+    await quirrel.respondTo(JSON.stringify({ result: "success" }), {});
+    expect(logMock).toHaveBeenCalledTimes(1);
+    expect(logMock).toHaveBeenLastCalledWith("Received job to routeName", {
+      result: "success",
+    });
+    expect(errorLogMock).toHaveBeenCalledTimes(0);
+
+    await quirrel.respondTo(JSON.stringify({ result: "fail" }), {});
+    expect(logMock).toHaveBeenCalledTimes(2);
+    expect(logMock).toHaveBeenLastCalledWith("Received job to routeName", {
+      result: "fail",
+    });
+    expect(errorLogMock).toHaveBeenCalledTimes(1);
+    expect(errorLogMock).toHaveBeenLastCalledWith(
+      "Error in job at routeName",
+      { result: "fail" },
+      new Error("yey,errors")
+    );
+  });
+
+  it("allows passing a custom logger function", async () => {
+    const receivedJob = jest.fn();
+    const processingError = jest.fn();
+
+    const quirrel = new QuirrelClient<{ result: "success" | "fail" }>({
+      route: "",
+      async handler(payload) {
+        if (payload.result === "fail") throw new Error("fail");
+      },
+      config: {
+        quirrelBaseUrl,
+        applicationBaseUrl: "http://localhost",
+      },
+      logger: {
+        receivedJob,
+        processingError,
+      },
+    });
+    await quirrel.respondTo(JSON.stringify({ result: "success" }), {});
+    expect(receivedJob).toBeCalledTimes(1);
+    expect(processingError).toBeCalledTimes(0);
+    expect(logMock).toHaveBeenCalledTimes(0);
+    expect(errorLogMock).toHaveBeenCalledTimes(0);
+
+    await quirrel.respondTo(JSON.stringify({ result: "fail" }), {});
+    expect(receivedJob).toBeCalledTimes(2);
+    expect(processingError).toBeCalledTimes(1);
+    expect(logMock).toHaveBeenCalledTimes(0);
+    expect(errorLogMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/client/test/logger.test.ts
+++ b/src/client/test/logger.test.ts
@@ -75,9 +75,11 @@ describe("client logger", () => {
         quirrelBaseUrl,
         applicationBaseUrl: "http://localhost",
       },
-      logger: {
-        receivedJob,
-        processingError,
+      options: {
+        logger: {
+          receivedJob,
+          processingError,
+        },
       },
     });
     await quirrel.respondTo(JSON.stringify({ result: "success" }), {});

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -6,7 +6,7 @@ import {
   EnqueueJobOpts,
   EnqueueJobOptions,
   Job,
-  CustomLogger,
+  QuirrelOptions,
 } from "./client";
 import bodyParser from "body-parser";
 
@@ -30,14 +30,12 @@ declare module "connect" {
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions,
-  logger?: CustomLogger<Payload>
+  options?: QuirrelOptions<Payload>,
 ): Queue<Payload> {
   const quirrel = new QuirrelClient({
     route,
     handler,
-    defaultJobOptions,
-    logger,
+    options,
   });
 
   const server = connect() as Queue<Payload>;
@@ -75,7 +73,7 @@ export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
   handler: () => Promise<void>,
-  logger?: CustomLogger
+  options?: QuirrelOptions
 ) {
-  return Queue(route, handler, {}, logger) as unknown;
+  return Queue(route, handler, options) as unknown;
 }

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -6,6 +6,7 @@ import {
   EnqueueJobOpts,
   EnqueueJobOptions,
   Job,
+  CustomLogger,
 } from "./client";
 import bodyParser from "body-parser";
 
@@ -29,12 +30,14 @@ declare module "connect" {
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions
+  defaultJobOptions?: DefaultJobOptions,
+  logger?: CustomLogger<Payload>
 ): Queue<Payload> {
   const quirrel = new QuirrelClient({
     route,
     handler,
     defaultJobOptions,
+    logger,
   });
 
   const server = connect() as Queue<Payload>;
@@ -71,7 +74,8 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
-  handler: () => Promise<void>
+  handler: () => Promise<void>,
+  logger?: CustomLogger
 ) {
-  return Queue(route, handler) as unknown;
+  return Queue(route, handler, {}, logger) as unknown;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,6 @@ export {
   EnqueueJobOptions,
   Job,
   QuirrelClient,
+  QuirrelOptions,
 } from "./client";
 export { runQuirrelDev } from "./cli/commands/index";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export {
   Job,
   QuirrelClient,
   QuirrelOptions,
+  QuirrelLogger,
 } from "./client";
 export { runQuirrelDev } from "./cli/commands/index";

--- a/src/next.ts
+++ b/src/next.ts
@@ -5,6 +5,7 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
+  CustomLogger,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 import type { IncomingHttpHeaders } from "http";
@@ -45,12 +46,14 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions
+  defaultJobOptions?: DefaultJobOptions,
+  logger?: CustomLogger<Payload>
 ): Queue<Payload> & NextApiHandler {
   const quirrel = new QuirrelClient<Payload>({
     defaultJobOptions,
     handler,
     route,
+    logger,
   });
 
   async function nextApiHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -83,7 +86,8 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
-  handler: () => Promise<void>
+  handler: () => Promise<void>,
+  logger?: CustomLogger
 ) {
-  return Queue(route, handler) as unknown;
+  return Queue(route, handler, {}, logger) as unknown;
 }

--- a/src/next.ts
+++ b/src/next.ts
@@ -5,7 +5,7 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
-  CustomLogger,
+  QuirrelOptions,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 import type { IncomingHttpHeaders } from "http";
@@ -46,14 +46,12 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions,
-  logger?: CustomLogger<Payload>
+  options?: QuirrelOptions,
 ): Queue<Payload> & NextApiHandler {
   const quirrel = new QuirrelClient<Payload>({
-    defaultJobOptions,
+    options,
     handler,
     route,
-    logger,
   });
 
   async function nextApiHandler(req: NextApiRequest, res: NextApiResponse) {
@@ -87,7 +85,7 @@ export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
   handler: () => Promise<void>,
-  logger?: CustomLogger
+  options?: QuirrelOptions
 ) {
-  return Queue(route, handler, {}, logger) as unknown;
+  return Queue(route, handler, options) as unknown;
 }

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,4 +1,4 @@
-import { EnqueueJobOptions, QuirrelClient } from "./client";
+import { CustomLogger, EnqueueJobOptions, QuirrelClient } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 import * as connect from "./connect";
 
@@ -9,9 +9,10 @@ registerDevelopmentDefaults({
 export function Queue<Payload>(
   path: string,
   handler: connect.QuirrelJobHandler<Payload>,
-  defaultJobOptions?: connect.DefaultJobOptions
+  defaultJobOptions?: connect.DefaultJobOptions,
+  logger?: CustomLogger<Payload>
 ): Omit<QuirrelClient<Payload>, "respondTo" | "makeRequest"> {
-  const client = connect.Queue(path, handler, defaultJobOptions);
+  const client = connect.Queue(path, handler, defaultJobOptions, logger);
 
   (client as any).path = path;
   (client as any).handler = client.handle;
@@ -22,9 +23,10 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
-  handler: () => Promise<void>
+  handler: () => Promise<void>,
+  logger?: CustomLogger
 ) {
-  return Queue(route, handler) as unknown;
+  return Queue(route, handler, {}, logger) as unknown;
 }
 
 export * from "./connect";

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,4 +1,4 @@
-import { CustomLogger, EnqueueJobOptions, QuirrelClient } from "./client";
+import { EnqueueJobOptions, QuirrelClient, QuirrelOptions } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 import * as connect from "./connect";
 
@@ -9,10 +9,9 @@ registerDevelopmentDefaults({
 export function Queue<Payload>(
   path: string,
   handler: connect.QuirrelJobHandler<Payload>,
-  defaultJobOptions?: connect.DefaultJobOptions,
-  logger?: CustomLogger<Payload>
+  options?: QuirrelOptions,
 ): Omit<QuirrelClient<Payload>, "respondTo" | "makeRequest"> {
-  const client = connect.Queue(path, handler, defaultJobOptions, logger);
+  const client = connect.Queue(path, handler, options);
 
   (client as any).path = path;
   (client as any).handler = client.handle;
@@ -24,9 +23,9 @@ export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
   handler: () => Promise<void>,
-  logger?: CustomLogger
+  options?: QuirrelOptions
 ) {
-  return Queue(route, handler, {}, logger) as unknown;
+  return Queue(route, handler, options) as unknown;
 }
 
 export * from "./connect";

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -5,7 +5,7 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
-  CustomLogger,
+  QuirrelOptions,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 
@@ -45,14 +45,12 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions,
-  logger?: CustomLogger<Payload>
+  options?: QuirrelOptions<Payload>,
 ): Queue<Payload> {
   const quirrel = new QuirrelClient<Payload>({
-    defaultJobOptions,
+    options,
     handler,
     route,
-    logger,
   });
 
   async function redwoodHandler(event: RedwoodEvent): Promise<RedwoodResponse> {
@@ -89,7 +87,7 @@ export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
   handler: () => Promise<void>,
-  logger?: CustomLogger
+  options?: QuirrelOptions
 ) {
-  return Queue(route, handler, {}, logger) as unknown;
+  return Queue(route, handler, options) as unknown;
 }

--- a/src/redwood.ts
+++ b/src/redwood.ts
@@ -5,10 +5,17 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
+  CustomLogger,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 
-export { Job, EnqueueJobOpts, EnqueueJobOptions, DefaultJobOptions, QuirrelJobHandler };
+export {
+  Job,
+  EnqueueJobOpts,
+  EnqueueJobOptions,
+  DefaultJobOptions,
+  QuirrelJobHandler,
+};
 
 registerDevelopmentDefaults({
   applicationBaseUrl: "http://localhost:8911",
@@ -38,12 +45,14 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions
+  defaultJobOptions?: DefaultJobOptions,
+  logger?: CustomLogger<Payload>
 ): Queue<Payload> {
   const quirrel = new QuirrelClient<Payload>({
     defaultJobOptions,
     handler,
     route,
+    logger,
   });
 
   async function redwoodHandler(event: RedwoodEvent): Promise<RedwoodResponse> {
@@ -79,7 +88,8 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
-  handler: () => Promise<void>
+  handler: () => Promise<void>,
+  logger?: CustomLogger
 ) {
-  return Queue(route, handler) as unknown;
+  return Queue(route, handler, {}, logger) as unknown;
 }

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -5,7 +5,7 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
-  CustomLogger,
+  QuirrelOptions,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 
@@ -35,14 +35,12 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions,
-  logger?: CustomLogger<Payload>
+  options?: QuirrelOptions<Payload>
 ): ActionFunction & Queue<Payload> {
   const quirrel = new QuirrelClient<Payload>({
-    defaultJobOptions,
+    options,
     handler,
     route,
-    logger,
   });
 
   async function action({ request }: DataFunctionArgs) {
@@ -79,7 +77,7 @@ export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
   handler: () => Promise<void>,
-  logger?: CustomLogger
+  options?: QuirrelOptions
 ) {
-  return Queue(route, handler, {}, logger) as unknown;
+  return Queue(route, handler, options) as unknown;
 }

--- a/src/sveltekit.ts
+++ b/src/sveltekit.ts
@@ -4,6 +4,7 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
+  CustomLogger,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 
@@ -32,15 +33,19 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions
+  defaultJobOptions?: DefaultJobOptions,
+  logger?: CustomLogger<Payload>
 ): Queue<Payload> {
   const quirrel = new QuirrelClient<Payload>({
     defaultJobOptions,
     handler,
     route,
+    logger,
   });
 
-  async function svelteHandler(request: SvelteRequest): Promise<SvelteResponse> {
+  async function svelteHandler(
+    request: SvelteRequest
+  ): Promise<SvelteResponse> {
     const { body, headers, status } = await quirrel.respondTo(
       request.body,
       request.headers
@@ -73,7 +78,8 @@ export function Queue<Payload>(
 export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
-  handler: () => Promise<void>
+  handler: () => Promise<void>,
+  logger?: CustomLogger
 ) {
-  return Queue(route, handler) as unknown;
+  return Queue(route, handler, {}, logger) as unknown;
 }

--- a/src/sveltekit.ts
+++ b/src/sveltekit.ts
@@ -4,7 +4,7 @@ import {
   Job,
   DefaultJobOptions,
   QuirrelJobHandler,
-  CustomLogger,
+  QuirrelOptions,
 } from "./client";
 import { registerDevelopmentDefaults } from "./client/config";
 
@@ -33,14 +33,12 @@ export type Queue<Payload> = Omit<
 export function Queue<Payload>(
   route: string,
   handler: QuirrelJobHandler<Payload>,
-  defaultJobOptions?: DefaultJobOptions,
-  logger?: CustomLogger<Payload>
+  options?: QuirrelOptions<Payload>,
 ): Queue<Payload> {
   const quirrel = new QuirrelClient<Payload>({
-    defaultJobOptions,
+    options,
     handler,
     route,
-    logger,
   });
 
   async function svelteHandler(
@@ -79,7 +77,7 @@ export function CronJob(
   route: string,
   cronSchedule: NonNullable<NonNullable<EnqueueJobOptions["repeat"]>["cron"]>,
   handler: () => Promise<void>,
-  logger?: CustomLogger
+  options?: QuirrelOptions
 ) {
-  return Queue(route, handler, {}, logger) as unknown;
+  return Queue(route, handler, options) as unknown;
 }


### PR DESCRIPTION
currently the logging is really simple and very verbose. this gives users the options to define their own logger functions for the quirrel client.