### PR TITLE
fix: typo in CronDetector searchpath

### DIFF
--- a/docs/docs/deploying.md
+++ b/docs/docs/deploying.md
@@ -17,6 +17,7 @@ If it doesn't, feel free to [reach out](mailto:troubleshooting@quirrel.dev).
 
 :::note Cron Jobs
 If you're using [CronJobs()](/api/cronjob), make sure to run `quirrel ci` during the deploy process.
+Make sure to have `QUIRREL_API_URL`, a `QUIRREL_TOKEN` and the `QUIRREL_BASE_URL` set when executing `quirrel ci`.
 
 ```json
 "scripts": { "vercel-build": "npm run build && quirrel ci" }

--- a/src/cli/cron-detector.ts
+++ b/src/cli/cron-detector.ts
@@ -104,7 +104,7 @@ export class CronDetector {
   ) {
     const rules = parseChokidarRulesFromGitignore(cwd);
     this.watcher = chokidar.watch(["**/*.[jt]s", "**/*.[jt]sx"], {
-      ignored: ["node_moduules", "**/node_modules", ...rules.ignoredPaths],
+      ignored: ["node_modules", "**/node_modules", ...rules.ignoredPaths],
       cwd,
     });
 
@@ -180,8 +180,9 @@ export class CronDetector {
       }
 
       if (!newJob.isValid) {
-        console.error(`
-🚨Encountered invalid cron expression: ${newJob.schedule}`);
+        console.error(
+          `🚨Encountered invalid cron expression: ${newJob.schedule}`
+        );
         return;
       }
 


### PR DESCRIPTION
I read up code on the CronDetector - found a typo and added a line more to the docs to make it easier for others to understand.