### PR TITLE
fix: use nonempty() for retry array type to match runtime validation

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -169,9 +169,10 @@ export interface EnqueueJobOptions {
 
   /**
    * If a job fails, retry it at along the specified intervals.
+   * Must contain at least one interval — an empty array is rejected at runtime.
    * @example ["5min", "1h", "1d"] // retries it after 5 minutes, 1:05 hours, and 1 day 1:05 hours
    */
-  retry?: (number | string)[];
+  retry?: [number | string, ...(number | string)[]];
 
   /**
    * Determines what to do when a job

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -129,7 +129,7 @@ const EnqueueJobOptionsSchema = z.object({
   id: z.string().optional(),
   exclusive: z.boolean().optional(),
   override: z.boolean().optional(),
-  retry: z.array(timeDuration("retry")).min(1).max(10).optional(),
+  retry: z.array(timeDuration("retry")).nonempty().max(10).optional(),
   delay: timeDuration("delay").optional(),
   runAt: z
     .date()


### PR DESCRIPTION
## Problem

`EnqueueJobOptions.retry` is typed as `(number | string)[]` which allows empty arrays, but the Zod schema at `src/client/index.ts:132` enforces `.min(1)` at runtime. Passing an empty retry array fails with:

```
body/retry must NOT have fewer than 1 items
```

The type doesn't reflect this constraint because Zod's `.min()` [does not change the inferred type](https://zod.dev/?id=min--max--length).

## Solution

Replace `.min(1)` with `.nonempty()`, which both:
- Enforces the minimum at runtime (same behavior)
- Narrows the inferred TypeScript type to `[T, ...T[]]` (at least one element)

The `.max(10)` constraint is preserved.

```diff
- retry: z.array(timeDuration("retry")).min(1).max(10).optional(),
+ retry: z.array(timeDuration("retry")).nonempty().max(10).optional(),
```

## Changes

- `src/client/index.ts` — Replaced `.min(1)` with `.nonempty()` on retry schema

Closes #1167